### PR TITLE
Hook up boroughs dropdown to API

### DIFF
--- a/src/components/LocationSearch.tsx
+++ b/src/components/LocationSearch.tsx
@@ -13,8 +13,10 @@ import {
   Spacer,
   Text,
 } from "@nycplanning/streetscape";
+import { useGetBoroughs } from "../gen";
 
 function LocationSearch() {
+  const { data: boroughs } = useGetBoroughs();
   return (
     <AccordionItem
       bg="white"
@@ -61,7 +63,15 @@ function LocationSearch() {
                 pt={4}
               >
                 <FormLabel>Borough</FormLabel>
-                <Select placeholder="-Select-" variant="base" />
+                <Select placeholder="-Select-" variant="base">
+                  {boroughs !== undefined
+                    ? boroughs.map((borough) => (
+                        <option key={borough.id} value={borough.id}>
+                          {borough.title}
+                        </option>
+                      ))
+                    : null}
+                </Select>
                 <FormErrorMessage>You must select a borough.</FormErrorMessage>
               </FormControl>
 


### PR DESCRIPTION
Uses the `useGetBoroughs` hook from the newly added Kubb-generated client to pull in the boroughs data from Zoning API and use it to populate the boroughs `<Select>` in location search