### PR TITLE
Stub MVTLayers for zoning districts and tax lots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-vite-boilerplate",
       "version": "0.0.0",
       "dependencies": {
+        "@deck.gl/geo-layers": "^8.9.32",
         "@deck.gl/react": "^8.9.31",
         "@kubb/cli": "^1.14.9",
         "@kubb/core": "^1.14.9",
@@ -1752,6 +1753,95 @@
         "mjolnir.js": "^2.7.0"
       }
     },
+    "node_modules/@deck.gl/extensions": {
+      "version": "8.9.32",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.9.32.tgz",
+      "integrity": "sha512-v2ALtHRnIj8F4MA6jwDq+rqZIl/1gU2d+kA9+MgLMiO2GW4o+IcR8IuCfL/wXe2e10Wjhmc7LlhpVc13ljOWlw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/shadertools": "^8.5.21"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@luma.gl/constants": "^8.0.0",
+        "@luma.gl/core": "^8.0.0",
+        "@math.gl/core": "^3.6.2",
+        "@math.gl/web-mercator": "^3.6.2",
+        "gl-matrix": "^3.0.0"
+      }
+    },
+    "node_modules/@deck.gl/geo-layers": {
+      "version": "8.9.32",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.9.32.tgz",
+      "integrity": "sha512-yJe96Z47qhdvnkN0u2DkDIAS2SGBS9XxWWT06lQpRIJnJl8PXStcHK0rvcZgdfMBW8INtcAfF8LnkEhqzbWnAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@loaders.gl/3d-tiles": "^3.4.13",
+        "@loaders.gl/gis": "^3.4.13",
+        "@loaders.gl/loader-utils": "^3.4.13",
+        "@loaders.gl/mvt": "^3.4.13",
+        "@loaders.gl/schema": "^3.4.13",
+        "@loaders.gl/terrain": "^3.4.13",
+        "@loaders.gl/tiles": "^3.4.13",
+        "@loaders.gl/wms": "^3.4.13",
+        "@luma.gl/constants": "^8.5.21",
+        "@luma.gl/experimental": "^8.5.21",
+        "@math.gl/core": "^3.6.2",
+        "@math.gl/culling": "^3.6.2",
+        "@math.gl/web-mercator": "^3.6.2",
+        "@types/geojson": "^7946.0.8",
+        "h3-js": "^3.7.0",
+        "long": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@deck.gl/extensions": "^8.0.0",
+        "@deck.gl/layers": "^8.0.0",
+        "@deck.gl/mesh-layers": "^8.0.0",
+        "@loaders.gl/core": "^3.4.13",
+        "@luma.gl/core": "^8.0.0"
+      }
+    },
+    "node_modules/@deck.gl/layers": {
+      "version": "8.9.32",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.9.32.tgz",
+      "integrity": "sha512-UuUBbRvBnL42pG70YY12YLspl6t/OacP4f/E3Ty0lliXe0m/5jJFW+moubsz3goBV0adMI+CQf57cdlqlfQ4AQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@loaders.gl/images": "^3.4.13",
+        "@loaders.gl/schema": "^3.4.13",
+        "@luma.gl/constants": "^8.5.21",
+        "@mapbox/tiny-sdf": "^2.0.5",
+        "@math.gl/core": "^3.6.2",
+        "@math.gl/polygon": "^3.6.2",
+        "@math.gl/web-mercator": "^3.6.2",
+        "earcut": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@loaders.gl/core": "^3.4.13",
+        "@luma.gl/core": "^8.0.0"
+      }
+    },
+    "node_modules/@deck.gl/mesh-layers": {
+      "version": "8.9.32",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.9.32.tgz",
+      "integrity": "sha512-6bsy54PrBHjZriEe3Rf1iBVAI8Afy3L1qAXqKemxYaH56rc5EYlrmD0E/zKcACikIRFmE7bgQz/i6hlSt7dBHg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@loaders.gl/gltf": "^3.4.13",
+        "@luma.gl/constants": "^8.5.21",
+        "@luma.gl/experimental": "^8.5.21",
+        "@luma.gl/shadertools": "^8.5.21"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@luma.gl/core": "^8.0.0"
+      }
+    },
     "node_modules/@deck.gl/react": {
       "version": "8.9.31",
       "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.9.31.tgz",
@@ -2726,6 +2816,29 @@
         "typescript": "^5.2.2"
       }
     },
+    "node_modules/@loaders.gl/3d-tiles": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.4.14.tgz",
+      "integrity": "sha512-cxStTSLIJgRZnkTBYTcp9FPVBQWQlJMzW1LRlaKWiwAHkOKBElszzApIIEvRvZGSrs8k8TUi6BJ1Y41iiANF7w==",
+      "dependencies": {
+        "@loaders.gl/draco": "3.4.14",
+        "@loaders.gl/gltf": "3.4.14",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/math": "3.4.14",
+        "@loaders.gl/tiles": "3.4.14",
+        "@math.gl/core": "^3.5.1",
+        "@math.gl/geospatial": "^3.5.1",
+        "long": "^5.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^3.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/3d-tiles/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/@loaders.gl/core": {
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.14.tgz",
@@ -2757,11 +2870,46 @@
         "@probe.gl/env": "4.0.4"
       }
     },
+    "node_modules/@loaders.gl/draco": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.4.14.tgz",
+      "integrity": "sha512-HwNFFt+dKZqFtzI0uVGvRkudFEZXxybJ+ZRsNkBbzAWoMM5L1TpuLs6DPsqPQUIT9HXNHzov18cZI0gK5bTJpg==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/schema": "3.4.14",
+        "@loaders.gl/worker-utils": "3.4.14",
+        "draco3d": "1.5.5"
+      }
+    },
+    "node_modules/@loaders.gl/gis": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.4.14.tgz",
+      "integrity": "sha512-5cmhIwioPpSkfNzFRM3PbFDecjpYIhtEOFbryu3rE37npKHLTD2tF4ocQxUPB+QVED6GLwWBdzJIs64UWGrqjw==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/schema": "3.4.14",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@math.gl/polygon": "^3.5.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/@loaders.gl/gltf": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.4.14.tgz",
+      "integrity": "sha512-jv+B5S/taiwzXAOu5D9nk1jjU9+JCCr/6/nGguCE2Ya3IX7CI1Nlnp20eKKhW8ZCEokZavMNT0bNbiJ5ahEFjA==",
+      "dependencies": {
+        "@loaders.gl/draco": "3.4.14",
+        "@loaders.gl/images": "3.4.14",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/textures": "3.4.14",
+        "@math.gl/core": "^3.5.1"
+      }
+    },
     "node_modules/@loaders.gl/images": {
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.14.tgz",
       "integrity": "sha512-tL447hTWhOKBOB87SE4hvlC8OkbRT0mEaW1a/wIS9f4HnYDa/ycRLMV+nvdvYMZur4isNPam44oiRqi7GcILkg==",
-      "peer": true,
       "dependencies": {
         "@loaders.gl/loader-utils": "3.4.14"
       }
@@ -2770,7 +2918,6 @@
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.14.tgz",
       "integrity": "sha512-HCTY2/F83RLbZWcTvWLVJ1vke3dl6Bye20HU1AqkA37J2vzHwOZ8kj6eee8eeSkIkf7VIFwjyhVJxe0flQE/Bw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "@loaders.gl/worker-utils": "3.4.14",
@@ -2781,25 +2928,128 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.4.tgz",
       "integrity": "sha512-SDuSY/D4yDL6LQDa69l/GCcnZLRiGYdyvYkxWb0CgnzTPdPrcdrzGkzkvpC3zsA4fEFw2smlDje370QGHwlisg==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/math": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.4.14.tgz",
+      "integrity": "sha512-OBEVX6Q5pMipbCAiZyX2+q1zRd0nw8M2dclpny05on8700OaKMwfs47wEUnbfCU3iyHad3sgsAxN3EIh+kuo9Q==",
+      "dependencies": {
+        "@loaders.gl/images": "3.4.14",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@math.gl/core": "^3.5.1"
+      }
+    },
+    "node_modules/@loaders.gl/mvt": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.4.14.tgz",
+      "integrity": "sha512-tozGmWvsJacjaLavjX4S/5yNDV9S4wJb7+vPG/nXWX2gTtgZ1mxcFQAtAJjokqpy37d1ZhLt+TXh0HrLoTmRgw==",
+      "dependencies": {
+        "@loaders.gl/gis": "3.4.14",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/schema": "3.4.14",
+        "@math.gl/polygon": "^3.5.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/@loaders.gl/schema": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.14.tgz",
+      "integrity": "sha512-r6BEDfUvbvzgUnh/MtkR5RzrkIwo1x1jtPFRTSJVsIZO7arXXlu3blffuv5ppEkKpNZ1Xzd9WtHp/JIkuctsmw==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7"
+      }
+    },
+    "node_modules/@loaders.gl/terrain": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.4.14.tgz",
+      "integrity": "sha512-vhchEVkPaWXnqd2ofujG2AEnBsk4hEw6LWSaFY7E3VMzNhI9l2EHvyU3+Hs03jYbXM4oLlQPGqd/T7x+5IMtig==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/images": "3.4.14",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/schema": "3.4.14",
+        "@mapbox/martini": "^0.2.0"
+      }
+    },
+    "node_modules/@loaders.gl/textures": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.4.14.tgz",
+      "integrity": "sha512-iKDHL2ZlOUud4/e3g0p0SyvkukznopYy6La3O6I9vDfKp8peuKMRRcTfFfd/zH0OqQC0hIhCXNz46vRLu7h6ng==",
+      "dependencies": {
+        "@loaders.gl/images": "3.4.14",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/schema": "3.4.14",
+        "@loaders.gl/worker-utils": "3.4.14",
+        "ktx-parse": "^0.0.4",
+        "texture-compressor": "^1.0.2"
+      }
+    },
+    "node_modules/@loaders.gl/tiles": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.4.14.tgz",
+      "integrity": "sha512-an3scxl65r74LW4WoIGgluBmQpMY9eb381y9mZmREphTP6bWEj96fL/tiR+G6TiE6HJqTv8O3PH6xwI9OQmEJg==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/math": "3.4.14",
+        "@math.gl/core": "^3.5.1",
+        "@math.gl/culling": "^3.5.1",
+        "@math.gl/geospatial": "^3.5.1",
+        "@math.gl/web-mercator": "^3.5.1",
+        "@probe.gl/stats": "^4.0.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^3.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/tiles/node_modules/@probe.gl/stats": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.4.tgz",
+      "integrity": "sha512-SDuSY/D4yDL6LQDa69l/GCcnZLRiGYdyvYkxWb0CgnzTPdPrcdrzGkzkvpC3zsA4fEFw2smlDje370QGHwlisg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/wms": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-3.4.14.tgz",
+      "integrity": "sha512-D1pObPSUj885zGPyHIb7GtcwpHQNk0T8nK/4EHb0SHLe0y1b4qwqSOswdS9geXT9Q61hyhl/L0zqyTgwjiMStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/images": "3.4.14",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/schema": "3.4.14",
+        "@loaders.gl/xml": "3.4.14",
+        "@turf/rewind": "^5.1.5",
+        "deep-strict-equal": "^0.2.0",
+        "lerc": "^4.0.1"
       }
     },
     "node_modules/@loaders.gl/worker-utils": {
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.14.tgz",
       "integrity": "sha512-PUSwxoAYbskisXd0KfYEQ902b0igBA2UAWdP6PzPvY+tJmobfh74dTNwrrBQ1rGXQxxmGx6zc6/ksX6mlIzIrg==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.3.1"
+      }
+    },
+    "node_modules/@loaders.gl/xml": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-3.4.14.tgz",
+      "integrity": "sha512-SNMGOHz4p8Cw+M6kxXhFEjXdNddJPOZY1rzNmRq7NYdGQlQYYeJdqV5HWzHx9BkoQYyrDXkrweGN0mY9QxCfeA==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.4.14",
+        "@loaders.gl/schema": "3.4.14",
+        "fast-xml-parser": "^4.2.5"
       }
     },
     "node_modules/@luma.gl/constants": {
       "version": "8.5.21",
       "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.21.tgz",
-      "integrity": "sha512-aJxayGxTT+IRd1vfpcgD/cKSCiVJjBNiuiChS96VulrmCvkzUOLvYXr42y5qKB4RyR7vOIda5uQprNzoHrhQAA==",
-      "peer": true
+      "integrity": "sha512-aJxayGxTT+IRd1vfpcgD/cKSCiVJjBNiuiChS96VulrmCvkzUOLvYXr42y5qKB4RyR7vOIda5uQprNzoHrhQAA=="
     },
     "node_modules/@luma.gl/core": {
       "version": "8.5.21",
@@ -2830,6 +3080,24 @@
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/stats": "^3.5.0",
         "@types/offscreencanvas": "^2019.7.0"
+      }
+    },
+    "node_modules/@luma.gl/experimental": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.21.tgz",
+      "integrity": "sha512-uFKPChGofyihOKxtqJy78QCQCDFnuMTK4QHrUX/qiTnvFSO8BgtTUevKvWGN9lBvq+uDD0lSieeF9yBzhQfAzw==",
+      "dependencies": {
+        "@luma.gl/constants": "8.5.21",
+        "@math.gl/core": "^3.5.0",
+        "earcut": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@loaders.gl/gltf": "^3.0.0",
+        "@loaders.gl/images": "^3.0.0",
+        "@luma.gl/engine": "^8.4.0",
+        "@luma.gl/gltools": "^8.4.0",
+        "@luma.gl/shadertools": "^8.4.0",
+        "@luma.gl/webgl": "^8.4.0"
       }
     },
     "node_modules/@luma.gl/gltools": {
@@ -2888,6 +3156,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@mapbox/martini": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/martini/-/martini-0.2.0.tgz",
+      "integrity": "sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ=="
+    },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
@@ -2941,11 +3214,38 @@
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz",
       "integrity": "sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@math.gl/types": "3.6.3",
         "gl-matrix": "^3.4.0"
+      }
+    },
+    "node_modules/@math.gl/culling": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-3.6.3.tgz",
+      "integrity": "sha512-3UERXHbaPlM6pnTk2MI7LeQ5CoelDZzDzghTTcv+HdQCZsT/EOEuEdYimETHtSxiyiOmsX2Un65UBLYT/rbKZg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/core": "3.6.3",
+        "gl-matrix": "^3.4.0"
+      }
+    },
+    "node_modules/@math.gl/geospatial": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.6.3.tgz",
+      "integrity": "sha512-6xf657lJnaecSarSzn02t0cnsCSkWb+39m4+im96v20dZTrLCWZ2glDQVzfuL91meDnDXjH4oyvynp12Mj5MFg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/core": "3.6.3",
+        "gl-matrix": "^3.4.0"
+      }
+    },
+    "node_modules/@math.gl/polygon": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz",
+      "integrity": "sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==",
+      "dependencies": {
+        "@math.gl/core": "3.6.3"
       }
     },
     "node_modules/@math.gl/sun": {
@@ -2960,14 +3260,12 @@
     "node_modules/@math.gl/types": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz",
-      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA==",
-      "peer": true
+      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA=="
     },
     "node_modules/@math.gl/web-mercator": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
       "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "gl-matrix": "^3.4.0"
@@ -3313,6 +3611,56 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+    },
+    "node_modules/@turf/invariant": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+      "integrity": "sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
+      "integrity": "sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+      "dependencies": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.11",
@@ -4130,6 +4478,14 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buf-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+      "integrity": "sha512-Bvx4xH00qweepGc43xFvMs5BKASXTbHaHm6+kDYIK9p/4iFwjATQkmPKHQSgJZzKbAymhztRbXUf1Nqhzl73/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -4762,6 +5118,18 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/core-assert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+      "integrity": "sha512-IG97qShIP+nrJCXMCgkNZgH7jZQ4n8RpPyPeXX++T6avR/KhLhgLiHKoEn5Rc1KjfycSfA9DMa6m+4C4eguHhw==",
+      "dependencies": {
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4881,6 +5249,17 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deep-strict-equal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
+      "integrity": "sha512-3daSWyvZ/zwJvuMGlzG1O+Ow0YSadGfb3jsh9xoCutv2tWyB9dA4YvR9L9/fSdDZa2dByYQe+TqapSGUrjnkoA==",
+      "dependencies": {
+        "core-assert": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/default-browser": {
       "version": "4.0.0",
@@ -5091,6 +5470,11 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.5.tgz",
+      "integrity": "sha512-JVuNV0EJzD3LBYhGyIXJLeBID/EVtmFO1ZNhAYflTgiMiAJlbhXQmRRda/azjc8MRVMHh0gqGhiqHUo5dIXM8Q=="
     },
     "node_modules/earcut": {
       "version": "2.2.4",
@@ -5869,6 +6253,27 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
+      "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -6343,6 +6748,16 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/h3-js": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.7.2.tgz",
+      "integrity": "sha512-LPjlHSwB9zQZrMqKloCZmmmt3yZzIK7nqPcXqwU93zT3TtYG6jP4tZBzAPouxut7lLjdFbMQ75wRBiKfpsnY7w==",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
+      }
+    },
     "node_modules/hammerjs": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
@@ -6523,6 +6938,17 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/import-fresh": {
@@ -6725,6 +7151,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-error": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
+      "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg=="
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
@@ -7250,6 +7681,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ktx-parse": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.0.4.tgz",
+      "integrity": "sha512-LY3nrmfXl+wZZdPxgJ3ZmLvG+wkOZZP3/dr4RbQj1Pk3Qwz44esOOSFFVQJcNWpXAtiNIC66WgXufX/SYgYz6A=="
+    },
+    "node_modules/lerc": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-4.0.4.tgz",
+      "integrity": "sha512-nHZH+ffiGPkgKUQtiZrljGUGV2GddvPcVTV5E345ZFncbKz+/rBIjDPrSxkiqW0EAtg1Jw7qAgRdaCwV+95Fow=="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7607,6 +8048,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/loose-envify": {
@@ -9863,6 +10312,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -9989,6 +10443,26 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/texture-compressor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/texture-compressor/-/texture-compressor-1.0.2.tgz",
+      "integrity": "sha512-dStVgoaQ11mA5htJ+RzZ51ZxIZqNOgWKAIvtjLrW1AliQQLCmrDqNzQZ8Jh91YealQ95DXt4MEduLzJmbs6lig==",
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "image-size": "^0.7.4"
+      },
+      "bin": {
+        "texture-compressor": "bin/texture-compressor.js"
+      }
+    },
+    "node_modules/texture-compressor/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "generate": "kubb generate"
   },
   "dependencies": {
+    "@deck.gl/geo-layers": "^8.9.32",
     "@deck.gl/react": "^8.9.31",
     "@kubb/cli": "^1.14.9",
     "@kubb/core": "^1.14.9",

--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,6 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+#root, body {
+  width: 100vw;
+  height: 100vh;
 }
 
 .logo {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useMediaQuery, Accordion } from "@nycplanning/streetscape";
 import LocationSearch from "./components/LocationSearch";
 import LayersFilters from "./components/LayersFilters";
 import { TaxLotDetails } from "./components/TaxLotDetails";
+import { taxLotsLayer, zoningDistrictsLayer } from "./layers";
 import { useGetTaxLotByBbl } from "./gen";
 
 function updateViewState({ viewState }: DeckGLProps) {
@@ -49,12 +50,13 @@ function App() {
   };
 
   return (
-    <DeckGL
-      initialViewState={INITIAL_VIEW_STATE}
-      controller={true}
-      onViewStateChange={updateViewState}
-    >
-      <MapProvider>
+    <MapProvider>
+      <DeckGL
+        initialViewState={INITIAL_VIEW_STATE}
+        controller={true}
+        onViewStateChange={updateViewState}
+        layers={[taxLotsLayer, zoningDistrictsLayer]}
+      >
         {/* Initial View State must be passed to map, despite being passed into DeckGL, or else the map will not appear until after you interact with it */}
         <Map
           initialViewState={INITIAL_VIEW_STATE}
@@ -85,26 +87,26 @@ function App() {
           alt="NYC Planning"
           src="https://raw.githubusercontent.com/NYCPlanning/dcp-logo/master/dcp_logo_772.png"
         />
-      </MapProvider>
 
-      <Accordion
-        id="map-selections"
-        position="fixed"
-        top={6}
-        left={6}
-        allowMultiple
-        width={"27.5rem"}
-        defaultIndex={[0, 1]}
-      >
-        <LocationSearch
-          handleBblSearched={(bbl) => {
-            setSelectedBbl(bbl);
-          }}
-        />
-        <LayersFilters />
-        <TaxLotDetails taxLot={taxLot === undefined ? null : taxLot} />
-      </Accordion>
-    </DeckGL>
+        <Accordion
+          id="map-selections"
+          position="fixed"
+          top={6}
+          left={6}
+          allowMultiple
+          width={"27.5rem"}
+          defaultIndex={[0, 1]}
+        >
+          <LocationSearch
+            handleBblSearched={(bbl) => {
+              setSelectedBbl(bbl);
+            }}
+          />
+          <LayersFilters />
+          <TaxLotDetails taxLot={taxLot === undefined ? null : taxLot} />
+        </Accordion>
+      </DeckGL>
+    </MapProvider>
   );
 }
 

--- a/src/components/FilterList.tsx
+++ b/src/components/FilterList.tsx
@@ -11,7 +11,7 @@ import TaxLotFilters from "./TaxLotFilters";
 
 function FilterList() {
   return (
-    <Accordion allowMultiple allowToggle>
+    <Accordion allowMultiple>
       <AccordionItem>
         <AccordionButton px={0} _hover={{ border: 0 }}>
           Zoning Districts

--- a/src/components/ZoningDistrictFilters.tsx
+++ b/src/components/ZoningDistrictFilters.tsx
@@ -13,7 +13,7 @@ import LegendSquare from "./LegendSquare";
 
 function ZoningDistrictFilters() {
   return (
-    <Accordion allowMultiple allowToggle>
+    <Accordion allowMultiple>
       <AccordionItem>
         <AccordionButton px={0} _hover={{ border: 0 }}>
           <Switch size="sm" pr={2} />

--- a/src/layers/index.ts
+++ b/src/layers/index.ts
@@ -1,0 +1,2 @@
+export * from "./taxLotsLayer";
+export * from "./zoningDistrictsLayer";

--- a/src/layers/taxLotsLayer.ts
+++ b/src/layers/taxLotsLayer.ts
@@ -1,0 +1,5 @@
+import { MVTLayer } from "@deck.gl/geo-layers/typed";
+
+export const taxLotsLayer = new MVTLayer({
+  id: "taxLots",
+});

--- a/src/layers/zoningDistrictsLayer.ts
+++ b/src/layers/zoningDistrictsLayer.ts
@@ -1,0 +1,5 @@
+import { MVTLayer } from "@deck.gl/geo-layers/typed";
+
+export const zoningDistrictsLayer = new MVTLayer({
+  id: "zoningDistricts",
+});


### PR DESCRIPTION
## Summary
* Install `@deck.gl/geo-layers` package for `MVTLayer`
* Create new files for each layer in a new `layers` folder and stub instances of `MVTLayer`. **This is meant to stub the code as minimally as possible so that the layer implementation work can begin. We may need to move these layers into React hooks later on to manage behavior.**
* Move `MapProvider` in `App.tsx` to wrap the `<Deck>` component. Without this, layers added to the Deck instance wouldn't render.
* Remove `allowToggle` from Accordion components where `allowMultiple` is set. This was causing a warning to be thrown in the console because the former is ignored when the latter is set