### PR TITLE
17 Add Zoning District detail panel (Desktop)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,8 +120,6 @@ function App() {
     pickable: true,
     onClick: (f: any) => {
       setSelectedZoningDistrictUuid(f.object.properties.id);
-      // setSelectedZoningDistrictUuid('0025a136-64fe-4838-bdf2-c3d3f80634cd')
-      // setSelectedZoningDistrictUuid('06673772-22df-4324-9a9e-816c1397e89e')
       setInfoPane("zoningDistrict");
     },
     getFillColor: (f: any) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,13 @@ import { useMediaQuery, Accordion } from "@nycplanning/streetscape";
 import LocationSearch from "./components/LocationSearch";
 import LayersFilters from "./components/LayersFilters";
 import { TaxLotDetails } from "./components/TaxLotDetails";
+import { ZoningDistrictDetails } from "./components/ZoningDistrictDetails";
 import { taxLotsLayer, processColors } from "./layers";
-import { useGetAllZoningDistrictClasses, useGetTaxLotByBbl } from "./gen";
+import {
+  useGetAllZoningDistrictClasses,
+  useGetTaxLotByBbl,
+  useGetZoningDistrictClassesByUuid,
+} from "./gen";
 import { MVTLayer } from "@deck.gl/geo-layers/typed";
 import { useStore } from "./store";
 import { DataFilterExtension } from "@deck.gl/extensions/typed";
@@ -38,7 +43,18 @@ function App() {
       },
     },
   );
+  const [selectedZoningDistrictClasses, setSelectedZoningDistrictClasses] =
+    useState<string | null>(null);
+  const { data: zoningDistrictClasses } = useGetZoningDistrictClassesByUuid(
+    selectedZoningDistrictClasses === null ? "" : selectedZoningDistrictClasses,
+    {
+      query: {
+        enabled: selectedZoningDistrictClasses !== null,
+      },
+    },
+  );
 
+  const setInfoPane = useStore((state) => state.setInfoPane);
   const anyZoningDistrictsVisibility = useStore(
     (state) => state.anyZoningDistrictsVisibility,
   );
@@ -96,6 +112,13 @@ function App() {
       [1, 1],
       [1, 1],
     ],
+    pickable: true,
+    onClick: (f: any) => {
+      setSelectedZoningDistrictClasses(f.object.properties.id);
+      // setSelectedZoningDistrictClasses('0025a136-64fe-4838-bdf2-c3d3f80634cd')
+      // setSelectedZoningDistrictClasses('06673772-22df-4324-9a9e-816c1397e89e')
+      setInfoPane("zoningDistrict");
+    },
     getFillColor: (f: any) => {
       let color = [192, 192, 192, 255];
       visibleZoningDistrictCategories.forEach((category) => {
@@ -180,11 +203,17 @@ function App() {
           <LocationSearch
             handleBblSearched={(bbl) => {
               setSelectedBbl(bbl);
+              setInfoPane("bbl");
             }}
           />
           <LayersFilters />
 
           <TaxLotDetails taxLot={taxLot === undefined ? null : taxLot} />
+          <ZoningDistrictDetails
+            zoningDistrictClasses={
+              new Set(zoningDistrictClasses?.zoningDistrictClasses)
+            }
+          />
         </Accordion>
       </DeckGL>
     </MapProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,13 +43,18 @@ function App() {
       },
     },
   );
-  const [selectedZoningDistrictClasses, setSelectedZoningDistrictClasses] =
-    useState<string | null>(null);
+
+  const selectedZoningDistrictUuid = useStore(
+    (state) => state.selectedZoningDistrictUuid,
+  );
+  const setSelectedZoningDistrictUuid = useStore(
+    (state) => state.setSelectedZoningDistrictUuid,
+  );
   const { data: zoningDistrictClasses } = useGetZoningDistrictClassesByUuid(
-    selectedZoningDistrictClasses === null ? "" : selectedZoningDistrictClasses,
+    selectedZoningDistrictUuid === null ? "" : selectedZoningDistrictUuid,
     {
       query: {
-        enabled: selectedZoningDistrictClasses !== null,
+        enabled: selectedZoningDistrictUuid !== null,
       },
     },
   );
@@ -114,9 +119,9 @@ function App() {
     ],
     pickable: true,
     onClick: (f: any) => {
-      setSelectedZoningDistrictClasses(f.object.properties.id);
-      // setSelectedZoningDistrictClasses('0025a136-64fe-4838-bdf2-c3d3f80634cd')
-      // setSelectedZoningDistrictClasses('06673772-22df-4324-9a9e-816c1397e89e')
+      setSelectedZoningDistrictUuid(f.object.properties.id);
+      // setSelectedZoningDistrictUuid('0025a136-64fe-4838-bdf2-c3d3f80634cd')
+      // setSelectedZoningDistrictUuid('06673772-22df-4324-9a9e-816c1397e89e')
       setInfoPane("zoningDistrict");
     },
     getFillColor: (f: any) => {

--- a/src/components/CloseableModal.tsx
+++ b/src/components/CloseableModal.tsx
@@ -23,7 +23,7 @@ export const CloseableModal = ({ children }: any) => {
         top={2}
         right={2}
         size="sm"
-        onClick={() => setInfoPane("")}
+        onClick={() => setInfoPane(null)}
       />
       <VStack alignItems={"flex-start"} alignContent={"flex-start"}>
         {children}

--- a/src/components/CloseableModal.tsx
+++ b/src/components/CloseableModal.tsx
@@ -1,0 +1,33 @@
+import { Box, VStack } from "@nycplanning/streetscape";
+import { CloseButton } from "@chakra-ui/react";
+import { useStore } from "../store";
+
+export const CloseableModal = ({ children }: any) => {
+  const setInfoPane = useStore((state) => state.setInfoPane);
+
+  return (
+    <Box
+      bg="white"
+      mb={6}
+      p={3}
+      pt={5}
+      borderRadius="base"
+      boxShadow="0px 8px 4px 0px rgba(0, 0, 0, 0.08);"
+      position="fixed"
+      top={6}
+      right={6}
+      // width={"296px"}
+    >
+      <CloseButton
+        position="absolute"
+        top={2}
+        right={2}
+        size="sm"
+        onClick={() => setInfoPane("")}
+      />
+      <VStack alignItems={"flex-start"} alignContent={"flex-start"}>
+        {children}
+      </VStack>
+    </Box>
+  );
+};

--- a/src/components/TaxLotDetails.tsx
+++ b/src/components/TaxLotDetails.tsx
@@ -1,32 +1,17 @@
 import { TaxLot } from "../gen";
-import {
-  Box,
-  Flex,
-  HStack,
-  Text,
-  VStack,
-  Link,
-} from "@nycplanning/streetscape";
-import { CloseButton } from "@chakra-ui/react";
+import { Flex, HStack, Text, VStack, Link } from "@nycplanning/streetscape";
+import { CloseableModal } from "./CloseableModal";
+import { useStore } from "../store";
 
 interface TaxLotDetailsProps {
   taxLot: TaxLot | null;
 }
 
 export const TaxLotDetails = ({ taxLot }: TaxLotDetailsProps) => {
-  return taxLot === null ? null : (
-    <Box
-      bg="white"
-      mb={6}
-      p={4}
-      borderRadius="base"
-      border="0"
-      position="fixed"
-      top={6}
-      right={6}
-      width={"27.5rem"}
-    >
-      <CloseButton position="absolute" top={2} right={2} size="sm" />
+  const infoPane = useStore((state) => state.infoPane);
+
+  return taxLot === null || infoPane !== "bbl" ? null : (
+    <CloseableModal>
       <VStack alignItems={"flex-start"} alignContent={"flex-start"}>
         <Text fontSize={"xl"} fontWeight={"bold"}>
           {taxLot.address}, [ZIP]
@@ -211,6 +196,6 @@ export const TaxLotDetails = ({ taxLot }: TaxLotDetailsProps) => {
           </VStack>
         </HStack>
       </VStack>
-    </Box>
+    </CloseableModal>
   );
 };

--- a/src/components/ZoningDistrictDetails.tsx
+++ b/src/components/ZoningDistrictDetails.tsx
@@ -1,0 +1,39 @@
+import { ZoningDistrictClass } from "../gen";
+import { Text, VStack } from "@nycplanning/streetscape";
+import { CloseableModal } from "./CloseableModal";
+import { ZoningDistrictDetailsInfo } from "./ZoningDistrictDetailsInfo";
+import { useStore } from "../store";
+
+interface ZoningDistrictClassesDetailsProps {
+  zoningDistrictClasses: Set<ZoningDistrictClass | null>;
+}
+
+export const ZoningDistrictDetails = ({
+  zoningDistrictClasses,
+}: ZoningDistrictClassesDetailsProps) => {
+  const infoPane = useStore((state) => state.infoPane);
+
+  const zds = [...zoningDistrictClasses];
+
+  return zoningDistrictClasses === null ||
+    infoPane !== "zoningDistrict" ? null : (
+    <CloseableModal>
+      <VStack
+        alignItems={"flex-start"}
+        alignContent={"flex-start"}
+        width={"296px"}
+      >
+        <Text fontSize={"lg"} fontWeight={"bold"}>
+          Zoning District {zds.map((zd) => zd?.id).join(", ")}
+        </Text>
+        {zds.map((district) => (
+          <ZoningDistrictDetailsInfo
+            key={district?.id}
+            zd={district}
+            multiDistrict={zds.length > 1}
+          />
+        ))}
+      </VStack>
+    </CloseableModal>
+  );
+};

--- a/src/components/ZoningDistrictDetails.tsx
+++ b/src/components/ZoningDistrictDetails.tsx
@@ -13,8 +13,6 @@ export const ZoningDistrictDetails = ({
 }: ZoningDistrictClassesDetailsProps) => {
   const infoPane = useStore((state) => state.infoPane);
 
-  const zds = [...zoningDistrictClasses];
-
   return zoningDistrictClasses === null ||
     infoPane !== "zoningDistrict" ? null : (
     <CloseableModal>
@@ -24,13 +22,16 @@ export const ZoningDistrictDetails = ({
         width={"296px"}
       >
         <Text fontSize={"lg"} fontWeight={"bold"}>
-          Zoning District {zds.map((zd) => zd?.id).join(", ")}
+          Zoning District{" "}
+          {Array.from(zoningDistrictClasses)
+            .map((zd) => zd?.id)
+            .join(", ")}
         </Text>
-        {zds.map((district) => (
+        {Array.from(zoningDistrictClasses).map((district) => (
           <ZoningDistrictDetailsInfo
             key={district?.id}
             zd={district}
-            multiDistrict={zds.length > 1}
+            multiDistrict={zoningDistrictClasses.size > 1}
           />
         ))}
       </VStack>

--- a/src/components/ZoningDistrictDetailsInfo.tsx
+++ b/src/components/ZoningDistrictDetailsInfo.tsx
@@ -1,0 +1,55 @@
+import { ZoningDistrictClass } from "../gen";
+import { HStack, Text, Link } from "@nycplanning/streetscape";
+
+interface ZoningDistrictClassesDetailsProps {
+  zd: ZoningDistrictClass | null;
+  multiDistrict: boolean;
+}
+
+export const ZoningDistrictDetailsInfo = ({
+  zd,
+  multiDistrict,
+}: ZoningDistrictClassesDetailsProps) => {
+  return (
+    <>
+      {multiDistrict ? (
+        <Text fontSize={"md"} fontWeight={700} pt={2} pb={0}>
+          Zoning District {zd?.id}
+        </Text>
+      ) : (
+        ""
+      )}
+      <Text fontSize={"md"} pt={0}>
+        {zd?.description}
+      </Text>
+      <Link href={zd?.url} isExternal alignSelf={"flex-start"}>
+        <HStack gap={2}>
+          <svg
+            viewBox="0 0 24 24"
+            focusable="false"
+            width="1.5em"
+            height="1.5em"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeWidth="2"
+            >
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+              <path d="M15 3h6v6"></path>
+              <path d="M10 14L21 3"></path>
+            </g>
+          </svg>
+          <Text
+            fontSize={"md"}
+            textDecorationLine={"underline"}
+            fontWeight={"bold"}
+          >
+            View the {zd?.id} districts guide
+          </Text>
+        </HStack>
+      </Link>
+    </>
+  );
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,8 +1,10 @@
 import { create } from "zustand";
 
 export type Store = {
-  infoPane: string;
-  setInfoPane: (info: string) => void;
+  infoPane: "zoningDistrict" | "bbl" | null;
+  setInfoPane: (info: "zoningDistrict" | "bbl" | null) => void;
+  selectedZoningDistrictUuid: string | null;
+  setSelectedZoningDistrictUuid: (uuid: string | null) => void;
   anyZoningDistrictsVisibility: boolean;
   toggleAnyZoningDistrictsVisibility: () => void;
   visibleZoningDistrictCategories: Set<string>;
@@ -18,10 +20,15 @@ export type Store = {
 };
 
 export const useStore = create<Store>()((set) => ({
-  infoPane: "",
-  setInfoPane: (info: string) =>
+  infoPane: null,
+  setInfoPane: (info: "zoningDistrict" | "bbl" | null) =>
     set(() => ({
       infoPane: info,
+    })),
+  selectedZoningDistrictUuid: null,
+  setSelectedZoningDistrictUuid: (uuid: string | null) =>
+    set(() => ({
+      selectedZoningDistrictUuid: uuid,
     })),
   anyZoningDistrictsVisibility: false,
   toggleAnyZoningDistrictsVisibility: () =>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 
 export type Store = {
+  infoPane: string;
+  setInfoPane: (info: string) => void;
   anyZoningDistrictsVisibility: boolean;
   toggleAnyZoningDistrictsVisibility: () => void;
   visibleZoningDistrictCategories: Set<string>;
@@ -16,6 +18,11 @@ export type Store = {
 };
 
 export const useStore = create<Store>()((set) => ({
+  infoPane: "",
+  setInfoPane: (info: string) =>
+    set(() => ({
+      infoPane: info,
+    })),
   anyZoningDistrictsVisibility: false,
   toggleAnyZoningDistrictsVisibility: () =>
     set((state) => ({


### PR DESCRIPTION
Completes #17 

Refactored some items and added the zoning district detail panel.

Clicking on the map and viewing the zoning district detail panel will not work until the map tile UUIDs are updated to match the ids in the zoning_district db table (or vice versa).  In the meantime, you can test the zoning district detail panel by replacing line 117 in App.tsx with the contents of line 118 (for a single district selection) or 119 (for a multiple district selection).