### PR TITLE
14/tax lot layers toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,7 +154,7 @@ function App() {
     // data: `${import.meta.env.VITE_ZONING_API_URL}/tax-lot/{z}/{x}/{y}.pbf`,
     data: `https://de-sandbox.nyc3.digitaloceanspaces.com/ae-pilot-project/tilesets/tax_lot/{z}/{x}/{y}.pbf`,
     getLineColor: () => {
-      let color = undefined;
+      let color = [0, 0, 0, 0];
       if (visibleTaxLotsBoundaries) color = [0, 0, 0];
       return color;
     },
@@ -173,6 +173,11 @@ function App() {
       }
       return color;
     },
+    pointType: "text",
+    getText: (f: any) => f.properties.lot,
+    getTextColor: [98, 98, 98, 255],
+    textFontFamily: "Helvetica Neue, Arial, sans-serif",
+    getTextSize: 8,
     updateTriggers: {
       getLineColor: [visibleTaxLotsBoundaries],
       getFillColor: [visibleLandUseColors],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,13 +149,15 @@ function App() {
     },
   });
 
-  console.log("app - landuses", landUses);
-
   const taxLotsLayer = new MVTLayer({
     id: "taxLots",
     // data: `${import.meta.env.VITE_ZONING_API_URL}/tax-lot/{z}/{x}/{y}.pbf`,
     data: `https://de-sandbox.nyc3.digitaloceanspaces.com/ae-pilot-project/tilesets/tax_lot/{z}/{x}/{y}.pbf`,
-    getLineColor: visibleTaxLotsBoundaries ? [0, 0, 0] : null,
+    getLineColor: () => {
+      let color = undefined;
+      if (visibleTaxLotsBoundaries) color = [0, 0, 0];
+      return color;
+    },
     visible: anyTaxLotsVisibility,
     minZoom: 15,
     maxZoom: 16,
@@ -163,8 +165,8 @@ function App() {
       let color = [192, 192, 192, 0];
       if (visibleLandUseColors && f.properties.layerName === "fill") {
         const landUseId = f.properties.landUseId;
-        const landUseColor = landUses
-          ? landUses.find((landUse) => landUseId === landUse.id)?.color
+        const landUseColor = landUses?.landUses
+          ? landUses.landUses.find((landUse) => landUseId === landUse.id)?.color
           : null;
         const landUseColorHex = landUseColor ? hexToRgba(landUseColor) : null;
         color = landUseColorHex ? landUseColorHex : color;
@@ -181,8 +183,7 @@ function App() {
   const INITIAL_VIEW_STATE = {
     longitude: -74.0008,
     latitude: 40.7018,
-    // TODO Change this back to 10
-    zoom: 16,
+    zoom: 10,
     pitch: 0,
     bearing: 0,
     maxZoom: 20,

--- a/src/components/LayersFilters.tsx
+++ b/src/components/LayersFilters.tsx
@@ -38,6 +38,16 @@ function LayersFilters() {
   const toggleAnyTaxLotsVisibility = useStore(
     (state) => state.toggleAnyTaxLotsVisibility,
   );
+  const visibleTaxLotsBoundaries = useStore(
+    (state) => state.visibleTaxLotsBoundaries,
+  );
+  const toggleVisibleTaxLotsBoundaries = useStore(
+    (state) => state.toggleVisibleTaxLotsBoundaries,
+  );
+  const visibleLandUseColors = useStore((state) => state.visibleLandUseColors);
+  const toggleVisibleLandUseColors = useStore(
+    (state) => state.toggleVisibleLandUseColors,
+  );
   const setDefaultStateBasedOnApiData = useStore(
     (state) => state.setDefaultStateBasedOnApiData,
   );
@@ -70,6 +80,14 @@ function LayersFilters() {
         zoningDistrictCategoryIds,
         zoningDistrictClassIds,
       );
+    }
+  }
+
+  function handleTaxLotsVisibility() {
+    toggleAnyTaxLotsVisibility();
+    if (!visibleTaxLotsBoundaries && !visibleLandUseColors) {
+      toggleVisibleTaxLotsBoundaries();
+      toggleVisibleLandUseColors();
     }
   }
 

--- a/src/components/LayersFilters.tsx
+++ b/src/components/LayersFilters.tsx
@@ -41,13 +41,7 @@ function LayersFilters() {
   const visibleTaxLotsBoundaries = useStore(
     (state) => state.visibleTaxLotsBoundaries,
   );
-  const toggleVisibleTaxLotsBoundaries = useStore(
-    (state) => state.toggleVisibleTaxLotsBoundaries,
-  );
   const visibleLandUseColors = useStore((state) => state.visibleLandUseColors);
-  const toggleVisibleLandUseColors = useStore(
-    (state) => state.toggleVisibleLandUseColors,
-  );
   const setDefaultStateBasedOnApiData = useStore(
     (state) => state.setDefaultStateBasedOnApiData,
   );

--- a/src/components/LayersFilters.tsx
+++ b/src/components/LayersFilters.tsx
@@ -52,6 +52,18 @@ function LayersFilters() {
     (state) => state.setDefaultStateBasedOnApiData,
   );
 
+  function getFilterCount() {
+    let zoningFilterCount = 0;
+    let taxLotFilterCount = 0;
+    if (anyZoningDistrictsVisibility)
+      zoningFilterCount = visibleZoningDistrictCategories.size;
+    if (anyTaxLotsVisibility) {
+      if (visibleTaxLotsBoundaries) taxLotFilterCount++;
+      if (visibleLandUseColors) taxLotFilterCount++;
+    }
+    return zoningFilterCount + taxLotFilterCount;
+  }
+
   function handleZoningDistrictsVisibility() {
     toggleAnyZoningDistrictsVisibility();
     // The below resets all toggles and checkboxes if they are all untoggled/unchecked
@@ -80,14 +92,6 @@ function LayersFilters() {
         zoningDistrictCategoryIds,
         zoningDistrictClassIds,
       );
-    }
-  }
-
-  function handleTaxLotsVisibility() {
-    toggleAnyTaxLotsVisibility();
-    if (!visibleTaxLotsBoundaries && !visibleLandUseColors) {
-      toggleVisibleTaxLotsBoundaries();
-      toggleVisibleLandUseColors();
     }
   }
 
@@ -216,12 +220,7 @@ function LayersFilters() {
                       border={"1px solid"}
                       borderColor={"brand.100"}
                     >
-                      {/* TODO: add the tax lots size once that variable exists */}
-                      Selected (
-                      {anyZoningDistrictsVisibility
-                        ? visibleZoningDistrictCategories.size
-                        : "0"}
-                      )
+                      Selected ({getFilterCount()})
                     </Text>
                   </AccordionButton>
                   <AccordionPanel px={0}>

--- a/src/components/TaxLotFilters.tsx
+++ b/src/components/TaxLotFilters.tsx
@@ -17,7 +17,6 @@ function TaxLotFilters() {
   const { data } = useGetLandUses();
 
   const {
-    anyTaxLotsVisibility,
     visibleTaxLotsBoundaries,
     toggleVisibleTaxLotsBoundaries,
     visibleLandUseColors,
@@ -30,9 +29,7 @@ function TaxLotFilters() {
         <Switch
           size="sm"
           pr={2}
-          onChange={() => {
-            if (anyTaxLotsVisibility) toggleVisibleTaxLotsBoundaries();
-          }}
+          onChange={toggleVisibleTaxLotsBoundaries}
           isChecked={visibleTaxLotsBoundaries}
         />
         Tax Lot Boundaries
@@ -44,9 +41,7 @@ function TaxLotFilters() {
             <Switch
               size="sm"
               pr={2}
-              onChange={() => {
-                if (anyTaxLotsVisibility) toggleVisibleLandUseColors();
-              }}
+              onChange={toggleVisibleLandUseColors}
               isChecked={visibleLandUseColors}
             />
             Land Use Colors

--- a/src/components/TaxLotFilters.tsx
+++ b/src/components/TaxLotFilters.tsx
@@ -11,21 +11,44 @@ import {
 } from "@nycplanning/streetscape";
 import LegendSquare from "./LegendSquare";
 import { useGetLandUses } from "../gen";
+import { useStore } from "../store";
 
 function TaxLotFilters() {
   const { data } = useGetLandUses();
 
+  const {
+    anyTaxLotsVisibility,
+    visibleTaxLotsBoundaries,
+    toggleVisibleTaxLotsBoundaries,
+    visibleLandUseColors,
+    toggleVisibleLandUseColors,
+  } = useStore((state) => state);
+
   return (
     <>
       <Flex alignSelf={"flex-start"}>
-        <Switch size="sm" pr={2} />
+        <Switch
+          size="sm"
+          pr={2}
+          onChange={() => {
+            if (anyTaxLotsVisibility) toggleVisibleTaxLotsBoundaries();
+          }}
+          isChecked={visibleTaxLotsBoundaries}
+        />
         Tax Lot Boundaries
       </Flex>
 
       <Accordion allowToggle border={0}>
         <AccordionItem border={0}>
           <AccordionButton px={0} _hover={{ border: 0 }}>
-            <Switch size="sm" pr={2} />
+            <Switch
+              size="sm"
+              pr={2}
+              onChange={() => {
+                if (anyTaxLotsVisibility) toggleVisibleLandUseColors();
+              }}
+              isChecked={visibleLandUseColors}
+            />
             Land Use Colors
             <Spacer />
             <AccordionIcon />

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,10 @@ export type Store = {
   toggleZoningDistrictClassVisibility: (categoryId: string) => void;
   anyTaxLotsVisibility: boolean;
   toggleAnyTaxLotsVisibility: () => void;
+  visibleTaxLotsBoundaries: boolean;
+  toggleVisibleTaxLotsBoundaries: () => void;
+  visibleLandUseColors: boolean;
+  toggleVisibleLandUseColors: () => void;
   setDefaultStateBasedOnApiData: (
     zoningDistrictCategoryIds: Array<string>,
     zoningDistrictClassIds: Array<string>,
@@ -58,6 +62,16 @@ export const useStore = create<Store>()((set) => ({
   toggleAnyTaxLotsVisibility: () =>
     set((state) => ({
       anyTaxLotsVisibility: !state.anyTaxLotsVisibility,
+    })),
+  visibleTaxLotsBoundaries: false,
+  toggleVisibleTaxLotsBoundaries: () =>
+    set((state) => ({
+      visibleTaxLotsBoundaries: !state.visibleTaxLotsBoundaries,
+    })),
+  visibleLandUseColors: false,
+  toggleVisibleLandUseColors: () =>
+    set((state) => ({
+      visibleLandUseColors: !state.visibleLandUseColors,
     })),
   setDefaultStateBasedOnApiData: (
     zoningDistrictCategoryIds: Array<string>,


### PR DESCRIPTION
This PR adds Tax Lots layer and filter functionality.

Final outstanding issue is Tax Lot boundaries displaying when the Tax Lots layer is on, regardless of the state of the filter. I've attempted to override the layer's getLineColor function to accurately reflect the state but have been unsuccessful.