### PR TITLE
Switch to controlled Deck viewState with custom zoom in and out controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-vite-boilerplate",
       "version": "0.0.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.1.1",
         "@deck.gl/extensions": "^8.9.33",
         "@deck.gl/geo-layers": "^8.9.32",
         "@deck.gl/react": "^8.9.31",
@@ -16,7 +17,7 @@
         "@kubb/swagger": "^1.14.9",
         "@kubb/swagger-tanstack-query": "^1.14.9",
         "@kubb/swagger-ts": "^1.14.9",
-        "@nycplanning/streetscape": "^0.8.2",
+        "@nycplanning/streetscape": "^0.9.0",
         "@tanstack/react-query": "^4.36.1",
         "axios": "^1.6.1",
         "maplibre-gl": "^3.4.0",
@@ -833,6 +834,18 @@
       "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.1.tgz",
+      "integrity": "sha512-3p30hdo4LlRZTT5CwoAJq3G9fHI0wDc0pBaMHj4SUn0yomO+RcDRlzhdXqdr5cVnzax44sqXJVnf3oQG0eI+4g==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -1733,9 +1746,9 @@
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "8.9.31",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.9.31.tgz",
-      "integrity": "sha512-Zb0SspilYJpxFlg9UyNjk4UN0BlpIQCq3CY/D39EgqdEiy1wvvkIu0zArqbyKCBI6ig/OjCnbpn7XwsDEkPEzQ==",
+      "version": "8.9.33",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.9.33.tgz",
+      "integrity": "sha512-0nCLINaht0df04v1dwibJP74+MkTY1yjMzy5hfmwyyvh+giBcQQ1BUQsre2ovgzeFlbT+zO3/NO5QsFavOvVPQ==",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -1773,9 +1786,9 @@
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "8.9.32",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.9.32.tgz",
-      "integrity": "sha512-yJe96Z47qhdvnkN0u2DkDIAS2SGBS9XxWWT06lQpRIJnJl8PXStcHK0rvcZgdfMBW8INtcAfF8LnkEhqzbWnAQ==",
+      "version": "8.9.33",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.9.33.tgz",
+      "integrity": "sha512-5r7HLn8MHOt3feVGtGbSfATqSMlZ8ZGUIkAwIKBqbeaMedodD4r6Zkuj75u1zqxHXeHWqVNJxQ96RwciLqAxLw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@loaders.gl/3d-tiles": "^3.4.13",
@@ -1805,9 +1818,9 @@
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "8.9.32",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.9.32.tgz",
-      "integrity": "sha512-UuUBbRvBnL42pG70YY12YLspl6t/OacP4f/E3Ty0lliXe0m/5jJFW+moubsz3goBV0adMI+CQf57cdlqlfQ4AQ==",
+      "version": "8.9.33",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.9.33.tgz",
+      "integrity": "sha512-gyFBSJHN3gC+8AvudOWsuyKajACRiULJI0EI3bELeK7q0/t/0PA5jV6UQPl92gl9Cd6E0mMRpLybtZ+TpRje9A==",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -1827,9 +1840,9 @@
       }
     },
     "node_modules/@deck.gl/mesh-layers": {
-      "version": "8.9.32",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.9.32.tgz",
-      "integrity": "sha512-6bsy54PrBHjZriEe3Rf1iBVAI8Afy3L1qAXqKemxYaH56rc5EYlrmD0E/zKcACikIRFmE7bgQz/i6hlSt7dBHg==",
+      "version": "8.9.33",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.9.33.tgz",
+      "integrity": "sha512-/pVesNF+5fhqHZA/NcUaVFIST5M7WzJ2yoKTIke9hLeGBM0dUT/bzZE8tIOh9IXjlhV/UQ6qdJhzUkuCg5AL3w==",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -1844,9 +1857,9 @@
       }
     },
     "node_modules/@deck.gl/react": {
-      "version": "8.9.31",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.9.31.tgz",
-      "integrity": "sha512-quecOXm9CJl4KELo/WHsoQ9ijl2KTTENFXPDP4FT9tr5XJ7S1i7eh1S+OjAnXu+0NatNMepPfRmPP+oonrOcTA==",
+      "version": "8.9.33",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.9.33.tgz",
+      "integrity": "sha512-q3DU4NFXqOEp6bkpvvLxCDhHWWx2Eu1c8OFw/14h6Tu7mv1XuaHafJw01LBi3S67sy8JSItwVb31kDMjdXtF9g==",
       "dependencies": {
         "@babel/runtime": "^7.0.0"
       },
@@ -3307,12 +3320,13 @@
       }
     },
     "node_modules/@nycplanning/streetscape": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@nycplanning/streetscape/-/streetscape-0.8.2.tgz",
-      "integrity": "sha512-FpoSV+B17MCX+7qq7LdMPAlQZVucVyuEOJ5NAT/pvSV18mTzXS0oReyTzVqHdkMCXLufRu4o0hqo7PXQlEvm9w==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@nycplanning/streetscape/-/streetscape-0.9.0.tgz",
+      "integrity": "sha512-n30LYFCxy+K7UvO3732cUqArKX6nMJF3y8DvqnyIWcuUhm8IhOw6MN1hm6j0MdbVUQ8JMOO4YEkZmLSe0xJpWw==",
       "hasInstallScript": true,
       "dependencies": {
         "@chakra-ui/cli": "^2.4.1",
+        "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/layout": "^2.3.1",
         "@chakra-ui/media-query": "^3.3.0",
         "@chakra-ui/react": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "generate": "kubb generate"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.1.1",
     "@deck.gl/extensions": "^8.9.33",
     "@deck.gl/geo-layers": "^8.9.32",
     "@deck.gl/react": "^8.9.31",
@@ -21,7 +22,7 @@
     "@kubb/swagger": "^1.14.9",
     "@kubb/swagger-tanstack-query": "^1.14.9",
     "@kubb/swagger-ts": "^1.14.9",
-    "@nycplanning/streetscape": "^0.8.2",
+    "@nycplanning/streetscape": "^0.9.0",
     "@tanstack/react-query": "^4.36.1",
     "axios": "^1.6.1",
     "maplibre-gl": "^3.4.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,9 @@ function App() {
     },
   );
 
+  const MAX_ZOOM = 20;
+  const MIN_ZOOM = 10;
+
   const setInfoPane = useStore((state) => state.setInfoPane);
   const anyZoningDistrictsVisibility = useStore(
     (state) => state.anyZoningDistrictsVisibility,
@@ -189,7 +192,7 @@ function App() {
   const [viewState, setViewState] = useState<ViewState>({
     longitude: -74.0008,
     latitude: 40.7018,
-    zoom: 15,
+    zoom: 10,
     bearing: 0,
     pitch: 0,
   });
@@ -213,7 +216,7 @@ function App() {
             ),
             bearing: newViewState.bearing,
             pitch: newViewState.pitch,
-            zoom: newViewState.zoom,
+            zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, newViewState.zoom)),
           });
         }}
         layers={[taxLotsLayer, zoningDistrictsLayer]}
@@ -244,7 +247,8 @@ function App() {
       </DeckGL>
       <ButtonGroup
         position="absolute"
-        bottom={28}
+        bottom={["unset", 28]}
+        top={[4, "unset"]}
         right={6}
         isAttached={true}
         orientation="vertical"
@@ -259,14 +263,15 @@ function App() {
           aria-label="Zoom in"
           icon={<AddIcon />}
           onClick={() => {
-            setViewState({
-              ...viewState,
-              zoom: viewState.zoom + 1,
-              transitionDuration: 750,
-              transitionEasing: (x) => {
-                return 1 - Math.pow(1 - x, 4);
-              },
-            });
+            viewState.zoom < MAX_ZOOM &&
+              setViewState({
+                ...viewState,
+                zoom: viewState.zoom + 1,
+                transitionDuration: 750,
+                transitionEasing: (x) => {
+                  return 1 - Math.pow(1 - x, 4);
+                },
+              });
           }}
         />
         <IconButton
@@ -279,14 +284,15 @@ function App() {
           aria-label="Zoom out"
           icon={<MinusIcon />}
           onClick={() => {
-            setViewState({
-              ...viewState,
-              zoom: viewState.zoom - 1,
-              transitionDuration: 750,
-              transitionEasing: (x) => {
-                return 1 - Math.pow(1 - x, 4);
-              },
-            });
+            viewState.zoom > MIN_ZOOM &&
+              setViewState({
+                ...viewState,
+                zoom: viewState.zoom - 1,
+                transitionDuration: 750,
+                transitionEasing: (x) => {
+                  return 1 - Math.pow(1 - x, 4);
+                },
+              });
           }}
         />
       </ButtonGroup>


### PR DESCRIPTION
This PR updates how we manage Deck.gl's `viewState` so that it is managed [externally](https://deck.gl/docs/developer-guide/interactivity#externally-manage-view-state) via React. This is opposed to the previous implementation that passed `initialViewState` to Deck and Maplibre and had each of them manage the state internally. This change also resolves a bug where the `NavigationControl` component wasn't actually working.

This change also moves us towards relying on the Maplibre/Mapbox-gl ecosystem as little as possible, which I think is good in the long run. The AttributionControl and ScaleControl components still work as expected but I implemented a custom control for zooming in and our using some Button components from our Design System.

One issue worth noting has to do with the typescript typings for `viewState`. The `viewState` prop on the `<DeckGL>` components appears to be `any` which is odd and making enforcing typing difficult. I want to do some more research on this eventually but, for now, I just implemented my own type with the properties I needed. 

The logic in `onViewStateChange` updates the viewState as a user moves/pans/zooms the map, while also enforcing min/max lat and long. The `onClick` functions show how to programmatically update the `viewState`. In that case, I am incrementing and decrementing zoom. The `transitionEasing` and `transitionDuration` props make use of [Deck's View State Transition API](https://deck.gl/docs/developer-guide/view-state-transitions). I got the function in `transitionEasing` from a site linked in Deck's docs - https://easings.net. Specifically, the function I'm using is "[easeOutQuart](https://easings.net/#easeOutQuart)"