### PR TITLE
43 Implement map tax lot selection functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import "./App.css";
 import DeckGL from "@deck.gl/react/typed";
 import { FlyToInterpolator } from "@deck.gl/core/typed";
+import { PathStyleExtension } from "@deck.gl/extensions/typed";
 import {
   useMediaQuery,
   Accordion,
@@ -160,16 +161,38 @@ function App() {
     id: "taxLots",
     // data: `${import.meta.env.VITE_ZONING_API_URL}/tax-lot/{z}/{x}/{y}.pbf`,
     data: `https://de-sandbox.nyc3.digitaloceanspaces.com/ae-pilot-project/tilesets/tax_lot/{z}/{x}/{y}.pbf`,
-    getLineColor: () => {
+    getLineColor: (f: any) => {
+      if (
+        selectedBbl ===
+        `${f.properties.borough}${f.properties.block}${f.properties.lot}`
+      ) {
+        return [43, 108, 176, 255];
+      }
       let color = [0, 0, 0, 0];
       if (visibleTaxLotsBoundaries) color = [0, 0, 0];
       return color;
+    },
+    extensions: [new PathStyleExtension({ dash: true })],
+    getDashArray: (f: any) => {
+      if (
+        selectedBbl ===
+        `${f.properties.borough}${f.properties.block}${f.properties.lot}`
+      ) {
+        return [2, 1.5];
+      }
+      return [2, 0];
     },
     visible: anyTaxLotsVisibility,
     pickable: true,
     minZoom: 15,
     maxZoom: 16,
     getFillColor: (f: any) => {
+      if (
+        selectedBbl ===
+        `${f.properties.borough}${f.properties.block}${f.properties.lot}`
+      ) {
+        return [43, 108, 176, 153];
+      }
       let color = [192, 192, 192, 0];
       if (visibleLandUseColors && f.properties.layerName === "fill") {
         const landUseId = f.properties.landUseId;
@@ -201,8 +224,9 @@ function App() {
     textFontFamily: "Helvetica Neue, Arial, sans-serif",
     getTextSize: 8,
     updateTriggers: {
-      getLineColor: [visibleTaxLotsBoundaries],
-      getFillColor: [visibleLandUseColors],
+      getLineColor: [visibleTaxLotsBoundaries, selectedBbl],
+      getDashArray: [selectedBbl],
+      getFillColor: [visibleLandUseColors, selectedBbl],
     },
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "./App.css";
 import DeckGL from "@deck.gl/react/typed";
+import { FlyToInterpolator } from "@deck.gl/core/typed";
 import {
   useMediaQuery,
   Accordion,
@@ -37,6 +38,7 @@ type ViewState = {
   pitch: number;
   transitionDuration?: number;
   transitionEasing?: (t: number) => number;
+  transitionInterpolator?: FlyToInterpolator;
 };
 
 function App() {
@@ -190,6 +192,8 @@ function App() {
         ...viewState,
         longitude: f.coordinate[0],
         latitude: f.coordinate[1],
+        transitionDuration: 750,
+        transitionInterpolator: new FlyToInterpolator(),
         zoom: 18,
       });
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,6 +164,7 @@ function App() {
       return color;
     },
     visible: anyTaxLotsVisibility,
+    pickable: true,
     minZoom: 15,
     maxZoom: 16,
     getFillColor: (f: any) => {
@@ -180,6 +181,12 @@ function App() {
     },
     pointType: "text",
     getText: (f: any) => f.properties.lot,
+    onClick: (f: any) => {
+      setSelectedBbl(
+        `${f.object.properties.borough}${f.object.properties.block}${f.object.properties.lot}`,
+      );
+      setInfoPane("bbl");
+    },
     getTextColor: [98, 98, 98, 255],
     textFontFamily: "Helvetica Neue, Arial, sans-serif",
     getTextSize: 8,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,12 @@ function App() {
         `${f.object.properties.borough}${f.object.properties.block}${f.object.properties.lot}`,
       );
       setInfoPane("bbl");
+      setViewState({
+        ...viewState,
+        longitude: f.coordinate[0],
+        latitude: f.coordinate[1],
+        zoom: 18,
+      });
     },
     getTextColor: [98, 98, 98, 255],
     textFontFamily: "Helvetica Neue, Arial, sans-serif",


### PR DESCRIPTION
When a user has the tax lot district layer on with one or both of the tax lot boundary and land use filters enabled:

- They can click on a tax lot on the map
- Upon clicking, the existing "TaxLotDetails` panel is populated with the data for the tax lot
- The map is panned to and centered on the tax lot

Completes #43 