### PR TITLE
43 Implement map tax lot selection functionality and search zoom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@kubb/swagger-ts": "^1.14.9",
         "@nycplanning/streetscape": "^0.9.0",
         "@tanstack/react-query": "^4.36.1",
+        "@turf/centroid": "^6.5.0",
         "axios": "^1.6.1",
         "maplibre-gl": "^3.4.0",
         "react": "^18.2.0",
@@ -3633,6 +3634,37 @@
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
+      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid/node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid/node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/clone": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@kubb/swagger-ts": "^1.14.9",
     "@nycplanning/streetscape": "^0.9.0",
     "@tanstack/react-query": "^4.36.1",
+    "@turf/centroid": "^6.5.0",
     "axios": "^1.6.1",
     "maplibre-gl": "^3.4.0",
     "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import "./App.css";
 import DeckGL from "@deck.gl/react/typed";
 import { FlyToInterpolator } from "@deck.gl/core/typed";
+import { PathStyleExtension } from "@deck.gl/extensions/typed";
 import {
   useMediaQuery,
   Accordion,
@@ -160,16 +161,38 @@ function App() {
     id: "taxLots",
     // data: `${import.meta.env.VITE_ZONING_API_URL}/tax-lot/{z}/{x}/{y}.pbf`,
     data: `https://de-sandbox.nyc3.digitaloceanspaces.com/ae-pilot-project/tilesets/tax_lot/{z}/{x}/{y}.pbf`,
-    getLineColor: () => {
+    getLineColor: (f: any) => {
+      if (
+        selectedBbl ===
+        `${f.properties.borough}${f.properties.block}${f.properties.lot}`
+      ) {
+        return [43, 108, 176, 255];
+      }
       let color = [0, 0, 0, 0];
       if (visibleTaxLotsBoundaries) color = [0, 0, 0];
       return color;
+    },
+    extensions: [new PathStyleExtension({ dash: true })],
+    getDashArray: (f: any) => {
+      if (
+        selectedBbl ===
+        `${f.properties.borough}${f.properties.block}${f.properties.lot}`
+      ) {
+        return [2, 1.5];
+      }
+      return [2, 0];
     },
     visible: anyTaxLotsVisibility,
     pickable: true,
     minZoom: 15,
     maxZoom: 16,
     getFillColor: (f: any) => {
+      if (
+        selectedBbl ===
+        `${f.properties.borough}${f.properties.block}${f.properties.lot}`
+      ) {
+        return [43, 108, 176, 153];
+      }
       let color = [192, 192, 192, 0];
       if (visibleLandUseColors && f.properties.layerName === "fill") {
         const landUseId = f.properties.landUseId;
@@ -201,8 +224,9 @@ function App() {
     textFontFamily: "Helvetica Neue, Arial, sans-serif",
     getTextSize: 8,
     updateTriggers: {
-      getLineColor: [visibleTaxLotsBoundaries],
-      getFillColor: [visibleLandUseColors],
+      getLineColor: [visibleTaxLotsBoundaries, selectedBbl],
+      getDashArray: [selectedBbl],
+      getFillColor: [visibleLandUseColors, selectedBbl],
     },
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "./App.css";
 import DeckGL from "@deck.gl/react/typed";
+import { FlyToInterpolator } from "@deck.gl/core/typed";
 import {
   useMediaQuery,
   Accordion,
@@ -37,6 +38,7 @@ type ViewState = {
   pitch: number;
   transitionDuration?: number;
   transitionEasing?: (t: number) => number;
+  transitionInterpolator?: FlyToInterpolator;
 };
 
 function App() {
@@ -190,6 +192,8 @@ function App() {
         ...viewState,
         longitude: f.coordinate[0],
         latitude: f.coordinate[1],
+        transitionDuration: 750,
+        transitionInterpolator: new FlyToInterpolator(),
         zoom: 18,
       });
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,6 +164,7 @@ function App() {
       return color;
     },
     visible: anyTaxLotsVisibility,
+    pickable: true,
     minZoom: 15,
     maxZoom: 16,
     getFillColor: (f: any) => {
@@ -180,6 +181,12 @@ function App() {
     },
     pointType: "text",
     getText: (f: any) => f.properties.lot,
+    onClick: (f: any) => {
+      setSelectedBbl(
+        `${f.object.properties.borough}${f.object.properties.block}${f.object.properties.lot}`,
+      );
+      setInfoPane("bbl");
+    },
     getTextColor: [98, 98, 98, 255],
     textFontFamily: "Helvetica Neue, Arial, sans-serif",
     getTextSize: 8,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,12 @@ function App() {
         `${f.object.properties.borough}${f.object.properties.block}${f.object.properties.lot}`,
       );
       setInfoPane("bbl");
+      setViewState({
+        ...viewState,
+        longitude: f.coordinate[0],
+        latitude: f.coordinate[1],
+        zoom: 18,
+      });
     },
     getTextColor: [98, 98, 98, 255],
     textFontFamily: "Helvetica Neue, Arial, sans-serif",


### PR DESCRIPTION
When a user has the tax lot district layer on with one or both of the tax lot boundary and land use filters enabled:

- They can click on a tax lot on the map
- Upon clicking, the existing "TaxLotDetails` panel is populated with the data for the tax lot
- The map is panned to and centered on the tax lot
- Also makes map view zoom to selected bbl on a successful search

Completes #43 