### PR TITLE
Update tax lot detail component to pull actual zoning districts and add max heights for map widgets

### DIFF
--- a/src/components/CloseableModal.tsx
+++ b/src/components/CloseableModal.tsx
@@ -16,6 +16,8 @@ export const CloseableModal = ({ children }: any) => {
       position="fixed"
       top={6}
       right={6}
+      maxH={"60vh"}
+      overflowY={"scroll"}
     >
       <CloseButton
         position="absolute"

--- a/src/components/LayersFilters.tsx
+++ b/src/components/LayersFilters.tsx
@@ -142,95 +142,101 @@ function LayersFilters() {
             borderColor="gray.400"
             borderRadius={"0 0 0.75rem 0.75rem"}
           >
-            <form>
-              <Flex id="layers" justify="center" gap={6}>
-                <VStack
-                  width={20}
-                  justify="center"
-                  alignSelf={"flex-start"}
-                  onClick={handleZoningDistrictsVisibility}
-                >
-                  <Box
-                    background={
-                      "url('./zoning_districts.png') 50% / cover no-repeat;"
-                    }
+            <Box maxH={"300px"} overflowY={"scroll"}>
+              <form>
+                <Flex id="layers" justify="center" gap={6}>
+                  <VStack
                     width={20}
-                    height={20}
-                    borderRadius={"12px"}
-                    border={anyZoningDistrictsVisibility ? "2px solid" : "0"}
-                    borderColor={"primary.500"}
-                  />
-                  <Text
-                    align="center"
-                    color={
-                      anyZoningDistrictsVisibility ? "primary.500" : "gray.600"
-                    }
-                    fontWeight={anyZoningDistrictsVisibility ? "500" : "400"}
+                    justify="center"
+                    alignSelf={"flex-start"}
+                    onClick={handleZoningDistrictsVisibility}
                   >
-                    Zoning Districts
-                  </Text>
-                </VStack>
-                <VStack
-                  width={20}
-                  justify="center"
-                  alignSelf={"flex-start"}
-                  onClick={toggleAnyTaxLotsVisibility}
-                >
-                  <Box
-                    background={"url('./tax_lots.png') 50% / cover no-repeat;"}
-                    width={20}
-                    height={20}
-                    borderRadius={"12px"}
-                    border={anyTaxLotsVisibility ? "2px solid" : "0"}
-                    borderColor={"primary.500"}
-                  />
-                  <Text
-                    align="center"
-                    color={anyTaxLotsVisibility ? "primary.500" : "gray.600"}
-                    fontWeight={anyTaxLotsVisibility ? "500" : "400"}
-                  >
-                    Tax Lots
-                  </Text>
-                </VStack>
-              </Flex>
-
-              <Accordion id="filters" allowToggle defaultIndex={0}>
-                <AccordionItem bg="white" border="0">
-                  <AccordionButton
-                    border="0"
-                    p={0}
-                    bg="white"
-                    _hover={{ backgroundColor: "white" }}
-                  >
-                    <Text textStyle="body" fontWeight={700} py={1}>
-                      Filters
-                    </Text>
-                    <AccordionIcon
-                      display={
-                        anyZoningDistrictsVisibility || anyTaxLotsVisibility
-                          ? ""
-                          : "none"
+                    <Box
+                      background={
+                        "url('./zoning_districts.png') 50% / cover no-repeat;"
                       }
+                      width={20}
+                      height={20}
+                      borderRadius={"12px"}
+                      border={anyZoningDistrictsVisibility ? "2px solid" : "0"}
+                      borderColor={"primary.500"}
                     />
-                    <Spacer />
                     <Text
-                      textStyle="body"
-                      backgroundColor={"brand.50"}
-                      px={2}
-                      py={1}
-                      borderRadius={"base"}
-                      border={"1px solid"}
-                      borderColor={"brand.100"}
+                      align="center"
+                      color={
+                        anyZoningDistrictsVisibility
+                          ? "primary.500"
+                          : "gray.600"
+                      }
+                      fontWeight={anyZoningDistrictsVisibility ? "500" : "400"}
                     >
-                      Selected ({getFilterCount()})
+                      Zoning Districts
                     </Text>
-                  </AccordionButton>
-                  <AccordionPanel px={0}>
-                    <FilterList />
-                  </AccordionPanel>
-                </AccordionItem>
-              </Accordion>
-            </form>
+                  </VStack>
+                  <VStack
+                    width={20}
+                    justify="center"
+                    alignSelf={"flex-start"}
+                    onClick={toggleAnyTaxLotsVisibility}
+                  >
+                    <Box
+                      background={
+                        "url('./tax_lots.png') 50% / cover no-repeat;"
+                      }
+                      width={20}
+                      height={20}
+                      borderRadius={"12px"}
+                      border={anyTaxLotsVisibility ? "2px solid" : "0"}
+                      borderColor={"primary.500"}
+                    />
+                    <Text
+                      align="center"
+                      color={anyTaxLotsVisibility ? "primary.500" : "gray.600"}
+                      fontWeight={anyTaxLotsVisibility ? "500" : "400"}
+                    >
+                      Tax Lots
+                    </Text>
+                  </VStack>
+                </Flex>
+
+                <Accordion id="filters" allowToggle defaultIndex={0}>
+                  <AccordionItem bg="white" border="0">
+                    <AccordionButton
+                      border="0"
+                      p={0}
+                      bg="white"
+                      _hover={{ backgroundColor: "white" }}
+                    >
+                      <Text textStyle="body" fontWeight={700} py={1}>
+                        Filters
+                      </Text>
+                      <AccordionIcon
+                        display={
+                          anyZoningDistrictsVisibility || anyTaxLotsVisibility
+                            ? ""
+                            : "none"
+                        }
+                      />
+                      <Spacer />
+                      <Text
+                        textStyle="body"
+                        backgroundColor={"brand.50"}
+                        px={2}
+                        py={1}
+                        borderRadius={"base"}
+                        border={"1px solid"}
+                        borderColor={"brand.100"}
+                      >
+                        Selected ({getFilterCount()})
+                      </Text>
+                    </AccordionButton>
+                    <AccordionPanel px={0}>
+                      <FilterList />
+                    </AccordionPanel>
+                  </AccordionItem>
+                </Accordion>
+              </form>
+            </Box>
           </AccordionPanel>
         </>
       )}

--- a/src/components/TaxLotDetails.tsx
+++ b/src/components/TaxLotDetails.tsx
@@ -1,5 +1,6 @@
 import { TaxLot } from "../gen";
 import { Flex, HStack, Text, VStack, Link } from "@nycplanning/streetscape";
+import { useGetZoningDistrictsByTaxLotBbl } from "../gen";
 import { CloseableModal } from "./CloseableModal";
 import { useStore } from "../store";
 
@@ -9,12 +10,17 @@ interface TaxLotDetailsProps {
 
 export const TaxLotDetails = ({ taxLot }: TaxLotDetailsProps) => {
   const infoPane = useStore((state) => state.infoPane);
-
+  const { data } = useGetZoningDistrictsByTaxLotBbl(
+    taxLot === null ? "" : taxLot.bbl,
+    {
+      query: { enabled: taxLot !== null },
+    },
+  );
   return taxLot === null || infoPane !== "bbl" ? null : (
     <CloseableModal>
       <VStack alignItems={"flex-start"} alignContent={"flex-start"}>
         <Text fontSize={"xl"} fontWeight={"bold"}>
-          {taxLot.address}, [ZIP]
+          {taxLot.address}
         </Text>
         <Text>Tax Lot: BBL{taxLot.bbl}</Text>
         <VStack
@@ -49,7 +55,8 @@ export const TaxLotDetails = ({ taxLot }: TaxLotDetailsProps) => {
               </VStack>
             </HStack>
             <Link
-              href={`http://maps.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=${taxLot.bbl}`}
+              // href={`http://maps.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=${taxLot.bbl}`}
+              href={`https://propertyinformationportal.nyc.gov/parcels/parcel/${taxLot.bbl}`}
               isExternal
               alignSelf={"flex-start"}
             >
@@ -72,7 +79,7 @@ export const TaxLotDetails = ({ taxLot }: TaxLotDetailsProps) => {
                   </g>
                 </svg>
                 <Text textDecorationLine={"underline"}>
-                  View Digital Tax Map
+                  View in Property Information Portal
                 </Text>
               </HStack>
             </Link>
@@ -104,58 +111,45 @@ export const TaxLotDetails = ({ taxLot }: TaxLotDetailsProps) => {
           <HStack alignItems={"flex-start"} py={2}>
             <Text fontWeight={"bold"}>Zoning District:</Text>
             <VStack alignItems={"flex-start"}>
-              <Text>C5-3</Text>
-              <Text>LM</Text>
+              {typeof data?.zoningDistricts === "undefined"
+                ? null
+                : data.zoningDistricts.map((zoningDistrict) => (
+                    <Text key={zoningDistrict.id}>{zoningDistrict.label}</Text>
+                  ))}
             </VStack>
           </HStack>
-          <Link href="https://chakra-ui.com" isExternal>
-            <HStack gap={1}>
-              <svg
-                viewBox="0 0 24 24"
-                focusable="false"
-                width="1.5em"
-                height="1.5em"
-              >
-                <g
-                  fill="none"
-                  stroke="currentColor"
-                  strokeLinecap="round"
-                  strokeWidth="2"
+          {typeof data?.zoningDistricts === "undefined"
+            ? null
+            : data.zoningDistricts.map((zoningDistrict) => (
+                <Link
+                  href={`https://www.nyc.gov/site/planning/zoning/districts-tools/${zoningDistrict.label.toLocaleLowerCase()}.page`}
+                  key={zoningDistrict.id}
+                  isExternal
                 >
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                  <path d="M15 3h6v6"></path>
-                  <path d="M10 14L21 3"></path>
-                </g>
-              </svg>
-              <Text textDecorationLine={"underline"}>
-                View C5-3 district guide
-              </Text>
-            </HStack>
-          </Link>
-          <Link href="https://chakra-ui.com" isExternal>
-            <HStack gap={1}>
-              <svg
-                viewBox="0 0 24 24"
-                focusable="false"
-                width="1.5em"
-                height="1.5em"
-              >
-                <g
-                  fill="none"
-                  stroke="currentColor"
-                  strokeLinecap="round"
-                  strokeWidth="2"
-                >
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                  <path d="M15 3h6v6"></path>
-                  <path d="M10 14L21 3"></path>
-                </g>
-              </svg>
-              <Text textDecorationLine={"underline"}>
-                View LM district guide
-              </Text>
-            </HStack>{" "}
-          </Link>
+                  <HStack gap={1}>
+                    <svg
+                      viewBox="0 0 24 24"
+                      focusable="false"
+                      width="1.5em"
+                      height="1.5em"
+                    >
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeWidth="2"
+                      >
+                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                        <path d="M15 3h6v6"></path>
+                        <path d="M10 14L21 3"></path>
+                      </g>
+                    </svg>
+                    <Text textDecorationLine={"underline"}>
+                      View {zoningDistrict.label} district guide
+                    </Text>
+                  </HStack>
+                </Link>
+              ))}
         </VStack>
         <Flex
           borderBottom="1px solid"


### PR DESCRIPTION
This PR fixes a couple issues to clean things up ahead of today's (1/26) demo.

* Removes the placeholder for zipcode from tax lot detail component
* Adds max height and scrolling to the tax lot and layer filters map widgets so content isn't cut off on shorter screen sizes
* Updates tax lot details component to pull actual zoning districts for the tax lot.